### PR TITLE
Fix wrong model key in __init__

### DIFF
--- a/whispercpp.pyx
+++ b/whispercpp.pyx
@@ -90,7 +90,7 @@ cdef class Whisper:
     cdef whisper_full_params params
 
     def __init__(self, model=DEFAULT_MODEL, pb=None):
-        model_fullname = f'model_ggml_{model}.bin'.encode('utf8')
+        model_fullname = f'ggml-{model}.bin'.encode('utf8')
         download_model(model_fullname)
         cdef bytes model_b = MODELS_DIR.encode('utf8')  + b'/' + model_fullname
         self.ctx = whisper_init(model_b)


### PR DESCRIPTION
7be71f8fe7135064a9c75cc93e2164733e9867f1 changed the MODELS dict to download the models from HuggingFace. It also changed the keys used for the dict, but didn't change the way the keys are derived from the model name.