### PR TITLE
Fixed wheel builds and model downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.core import setup
+from distutils.extension import Extension
 from Cython.Build import cythonize
 import numpy, os, sys
 
@@ -10,6 +11,17 @@ else:
     os.environ['CFLAGS']   = '-mavx -mavx2 -mfma -mf16c -O3 -std=c11'
     os.environ['CXXFLAGS'] = '-mavx -mavx2 -mfma -mf16c -O3 -std=c++11'
 
+ext_modules = [
+    Extension(
+        name="whispercpp",
+        sources=["whispercpp.pyx", "whisper.cpp/whisper.cpp"],
+        language="c++",
+        extra_compile_args=["-std=c++11"],
+   )
+]
+ext_modules = cythonize(ext_modules)
+
+whisper_clib = ('whisper_clib', {'sources': ['whisper.cpp/ggml.c']})
 
 setup(
     name='whispercpp',
@@ -17,6 +29,7 @@ setup(
     description='Python bindings for whisper.cpp',
     author='Luke Southam',
     author_email='luke@devthe.com',
+    libraries=[whisper_clib],
     ext_modules = cythonize("whispercpp.pyx"),
     include_dirs = ['./whisper.cpp/', numpy.get_include()],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ from Cython.Build import cythonize
 import numpy, os, sys
 
 if sys.platform == 'darwin':
-    os.environ['CFLAGS']   = '-DGGML_USE_ACCELERATE -O3 -std=c11'
+    os.environ['CFLAGS']   = '-DGGML_USE_ACCELERATE -O3 -std=gnu11'
     os.environ['CXXFLAGS'] = '-DGGML_USE_ACCELERATE -O3 -std=c++11'
     os.environ['LDFLAGS']  = '-framework Accelerate'
 else:
-    os.environ['CFLAGS']   = '-mavx -mavx2 -mfma -mf16c -O3 -std=c11'
+    os.environ['CFLAGS']   = '-mavx -mavx2 -mfma -mf16c -O3 -std=gnu11'
     os.environ['CXXFLAGS'] = '-mavx -mavx2 -mfma -mf16c -O3 -std=c++11'
 
 ext_modules = [

--- a/whispercpp.pyx
+++ b/whispercpp.pyx
@@ -1,7 +1,5 @@
 #!python
 # cython: language_level=3
-# distutils: language = c++
-# distutils: sources= ./whisper.cpp/whisper.cpp ./whisper.cpp/ggml.c
 
 import ffmpeg
 import numpy as np

--- a/whispercpp.pyx
+++ b/whispercpp.pyx
@@ -75,6 +75,7 @@ cdef whisper_full_params default_params() nogil:
     params.print_realtime = True
     params.print_progress = True
     params.translate = False
+    params.language = <const char *> LANGUAGE
     n_threads = N_THREADS
     return params
 

--- a/whispercpp.pyx
+++ b/whispercpp.pyx
@@ -7,7 +7,7 @@ import requests
 import os
 from pathlib import Path
 
-MODELS_DIR = str(Path('~/ggml-models').expanduser())
+MODELS_DIR = str(Path('~/.ggml-models').expanduser())
 print("Saving models to:", MODELS_DIR)
 
 
@@ -37,6 +37,7 @@ def download_model(model):
     print(f'Downloading {model}...')
     url = MODELS[model.decode()]
     r = requests.get(url, allow_redirects=True)
+    os.makedirs(MODELS_DIR, exist_ok=True)
     with open(MODELS_DIR + "/" + model.decode(), 'wb') as f:
         f.write(r.content)
 
@@ -78,7 +79,6 @@ cdef whisper_full_params default_params() nogil:
     params.print_realtime = True
     params.print_progress = True
     params.translate = False
-    params.language = <const char *> LANGUAGE
     n_threads = N_THREADS
     return params
 


### PR DESCRIPTION
This pull request fixes 3 issues:

1. The wheel did not build correctly because -std=c11 was being passed to the C++ compiler. Fixed by having Cython compile a separate C library.
2. The wheel did also not build correctly because ggml.c uses some GNU features. The correct flag for the C compiler is -std=gnu11. This should fix #6.
3. Models downloaded to ~/ggml-models, which is a non-standard path for storing application data. Additionally, saving the model would fail if the directory did not already exist.